### PR TITLE
fix Java accessors generation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ip-intelligence-dotnet"]
 	path = ip-intelligence-dotnet
-	url = https://github.com/51degrees/ip-intelligence-dotnet
+	url = ../ip-intelligence-dotnet

--- a/PropertyGenerator.sln
+++ b/PropertyGenerator.sln
@@ -5,14 +5,6 @@ VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PropertyGenerator", "PropertyGenerator\PropertyGenerator.csproj", "{B7C672E1-9490-42A5-A7E8-AC207B4E2167}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FiftyOne.IpIntelligence.CPP", "ip-intelligence-dotnet\FiftyOne.IpIntelligence\ip-intelligence-cxx\VisualStudio\FiftyOne.IpIntelligence.CPP\FiftyOne.IpIntelligence.CPP.vcxproj", "{341FD8CB-9456-4711-BEC8-C4A218FA1C6C}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FiftyOne.IpIntelligence.C", "ip-intelligence-dotnet\FiftyOne.IpIntelligence\ip-intelligence-cxx\VisualStudio\FiftyOne.IpIntelligence.C\FiftyOne.IpIntelligence.C.vcxproj", "{EDDF7B03-A483-4B52-9234-4585AF17B284}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FiftyOne.Common.C", "ip-intelligence-dotnet\FiftyOne.IpIntelligence\ip-intelligence-cxx\src\common-cxx\VisualStudio\FiftyOne.Common.C\FiftyOne.Common.C.vcxproj", "{8E1B0B4C-8220-4E7B-A838-B4B3DDB4CF15}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FiftyOne.Common.CPP", "ip-intelligence-dotnet\FiftyOne.IpIntelligence\ip-intelligence-cxx\src\common-cxx\VisualStudio\FiftyOne.Common.CPP\FiftyOne.Common.CPP.vcxproj", "{01DCCD38-27CC-4C1A-851F-F1700EDF8BB5}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FiftyOne.IpIntelligence.Shared", "ip-intelligence-dotnet\FiftyOne.IpIntelligence.Shared\FiftyOne.IpIntelligence.Shared.csproj", "{6FD12003-0EEF-471D-822B-D90DA3554CD0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FiftyOne.IpIntelligence.Engine.OnPremise", "ip-intelligence-dotnet\FiftyOne.IpIntelligence.Engine.OnPremise\FiftyOne.IpIntelligence.Engine.OnPremise.csproj", "{10248EF5-F8B1-4541-8208-9AA0141A7D59}"

--- a/PropertyGenerator/JavaClassBuilder.cs
+++ b/PropertyGenerator/JavaClassBuilder.cs
@@ -90,7 +90,7 @@ namespace PropertyGenerationTool
         {
             var type = GetReturnType(property, formatType);
             var parts = type.Split(new[] { '<', '>', ','}, StringSplitOptions.RemoveEmptyEntries);
-            return $"public {type} {GetGetterName(property)}() {{ return getAs(\"{GetPropertyName(property).ToLower()}\", {string.Join(", ", parts.Select(p => p + ".class"))}.class); }}";
+            return $"public {type} {GetGetterName(property)}() {{ return getAs(\"{GetPropertyName(property).ToLower()}\", {string.Join(", ", parts.Select(p => p + ".class"))}); }}";
         }
 
         internal void BuildInterface(

--- a/PropertyGenerator/PropertyGenerator.csproj
+++ b/PropertyGenerator/PropertyGenerator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.DeviceDetection.Hash.Engine.OnPremise" Version="4.4.201" />
+    <PackageReference Include="FiftyOne.DeviceDetection.Hash.Engine.OnPremise" Version="4.4.213" />
     <PackageReference Include="FiftyOne.MetaData" Version="5.0.28" />
   </ItemGroup>
 


### PR DESCRIPTION
# Why? 

The code generated for Java accessors contained double `.class.class` instead of `.class` see here: https://github.com/51Degrees/device-detection-java/pull/306/files#diff-2cd80cc03e6376d7316389eeb904af7bea6aeb069a91b05f6f5048d08a75c483R56 - this does not compile.  This PR addresses the issue.

# Additional changes

* Also updated DD package ref to the latest
* Removed non-existant project references from PropertyGenerator.sln