### PR TITLE
Fix Java accessors file generation for IPIntelligence

### DIFF
--- a/PropertyGenerator/DeviceDetection.cs
+++ b/PropertyGenerator/DeviceDetection.cs
@@ -75,7 +75,9 @@ namespace PropertyGenerationTool
                 "DeviceData",
                 _copyright,
                 "fiftyone.devicedetection.shared",
-                new string[0],
+                [
+                    "fiftyone.pipeline.core.data.types.JavaScript",
+                ],
                 _engine.Properties.ToArray(),
                 (s) => $"AspectPropertyValue<{s}>",
                 basePath + "/DeviceData.java");
@@ -87,7 +89,9 @@ namespace PropertyGenerationTool
                 "DeviceData",
                 _copyright,
                 "fiftyone.devicedetection.shared",
-                new string[0],
+                [
+                    "fiftyone.pipeline.core.data.types.JavaScript",
+                ],
                 _engine.Properties.ToArray(),
                 (s) => $"AspectPropertyValue<{s}>",
                 basePath + "/DeviceDataBase.java");

--- a/PropertyGenerator/IpIntelligence.cs
+++ b/PropertyGenerator/IpIntelligence.cs
@@ -70,9 +70,11 @@ namespace PropertyGenerator
                 "IPIntelligenceData",
                 _copyright,
                 "fiftyone.ipintelligence.shared",
-                new string[0],
+                [
+                    "fiftyone.pipeline.core.data.IWeightedValue",
+                ],
                 _engine.Properties.ToArray(),
-                (s) => $"IReadOnlyList<IWeightedValue<{s}>>",
+                (s) => $"AspectPropertyValue<List<IWeightedValue<{s}>>>",
                 basePath + "/IPIntelligenceData.java");
             Console.WriteLine(String.Format(
                 "Building IPIntelligenceDataBase.java for in '{0}'.",
@@ -82,9 +84,11 @@ namespace PropertyGenerator
                 "IPIntelligenceData",
                 _copyright,
                 "fiftyone.ipintelligence.shared",
-                new string[0],
+                [
+                    "fiftyone.pipeline.core.data.IWeightedValue",
+                ],
                 _engine.Properties.ToArray(),
-                (s) => $"IReadOnlyList<IWeightedValue<{s}>>",
+                (s) => $"AspectPropertyValue<List<IWeightedValue<{s}>>>",
                 basePath + "/IPIntelligenceDataBase.java");
         }
     }

--- a/PropertyGenerator/IpIntelligence.cs
+++ b/PropertyGenerator/IpIntelligence.cs
@@ -61,6 +61,10 @@ namespace PropertyGenerator
 
         public override void BuildJava(string basePath)
         {
+            IEnumerable<string> imports = [
+                "java.net.InetAddress",
+                "fiftyone.pipeline.core.data.IWeightedValue",
+            ];
             Console.WriteLine(String.Format(
                 "Building IPIntelligenceData.java for in '{0}'.",
                 new DirectoryInfo(basePath).FullName));
@@ -70,9 +74,7 @@ namespace PropertyGenerator
                 "IPIntelligenceData",
                 _copyright,
                 "fiftyone.ipintelligence.shared",
-                [
-                    "fiftyone.pipeline.core.data.IWeightedValue",
-                ],
+                imports,
                 _engine.Properties.ToArray(),
                 (s) => $"AspectPropertyValue<List<IWeightedValue<{s}>>>",
                 basePath + "/IPIntelligenceData.java");
@@ -84,9 +86,7 @@ namespace PropertyGenerator
                 "IPIntelligenceData",
                 _copyright,
                 "fiftyone.ipintelligence.shared",
-                [
-                    "fiftyone.pipeline.core.data.IWeightedValue",
-                ],
+                imports,
                 _engine.Properties.ToArray(),
                 (s) => $"AspectPropertyValue<List<IWeightedValue<{s}>>>",
                 basePath + "/IPIntelligenceDataBase.java");

--- a/PropertyGenerator/JavaClassBuilder.cs
+++ b/PropertyGenerator/JavaClassBuilder.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -64,6 +65,9 @@ namespace PropertyGenerationTool
                 case Type javaScriptType when javaScriptType == typeof(JavaScript):
                     typeString = "JavaScript";
                     break;
+                case Type javaScriptType when javaScriptType == typeof(IPAddress):
+                    typeString = "InetAddress";
+                    break;
                 case Type stringType when stringType == typeof(String):
                 default:
                     typeString = "String";
@@ -97,7 +101,7 @@ namespace PropertyGenerationTool
             string name,
             string copyright,
             string package,
-            string[] imports,
+            IEnumerable<string> imports,
             T[] properties,
             Func<string, string> formatType,
             string outputPath)
@@ -146,7 +150,7 @@ namespace PropertyGenerationTool
             string interfaceName,
             string copyright,
             string package,
-            string[] imports,
+            IEnumerable<string> imports,
             T[] properties,
             Func<string, string> formatType,
             string outputPath)

--- a/PropertyGenerator/JavaClassBuilder.cs
+++ b/PropertyGenerator/JavaClassBuilder.cs
@@ -112,7 +112,6 @@ namespace PropertyGenerationTool
                 {
                     writer.WriteLine($"import {import};");
                 }
-                writer.WriteLine("import fiftyone.pipeline.core.data.types.JavaScript;");
                 writer.WriteLine("import fiftyone.pipeline.engines.data.AspectData;");
                 writer.WriteLine("import fiftyone.pipeline.engines.data.AspectPropertyValue;");
                 writer.WriteLine("import java.util.List;");
@@ -156,14 +155,13 @@ namespace PropertyGenerationTool
             using (var writer = new StreamWriter(outputStream))
             {
                 writer.WriteLine(copyright);
-                writer.WriteLine("package fiftyone.devicedetection.shared;");
+                writer.WriteLine($"package {package};");
 
                 foreach (var import in imports)
                 {
                     writer.WriteLine($"import {import};");
                 }
                 writer.WriteLine("import fiftyone.pipeline.core.data.FlowData;");
-                writer.WriteLine("import fiftyone.pipeline.core.data.types.JavaScript;");
                 writer.WriteLine("import fiftyone.pipeline.engines.data.AspectData;");
                 writer.WriteLine("import fiftyone.pipeline.engines.data.AspectDataBase;");
                 writer.WriteLine("import fiftyone.pipeline.engines.data.AspectPropertyMetaData;");
@@ -185,7 +183,7 @@ namespace PropertyGenerationTool
                 writer.WriteLine(" * @param missingPropertyService service used to determine the reason for");
                 writer.WriteLine(" *                               a property value being missing");
                 writer.WriteLine(" */");
-                writer.WriteLine("\tprotected DeviceDataBase(");
+                writer.WriteLine($"\tprotected {name}(");
                 writer.WriteLine("\t\tLogger logger,");
                 writer.WriteLine("\t\tFlowData flowData,");
                 writer.WriteLine("\t\tAspectEngine<? extends AspectData, ? extends AspectPropertyMetaData> engine,");


### PR DESCRIPTION
### Changes

- Move `JavaScript` class import from `JavaClassBuilder` to `DeviceDetection`.
- Fix property type lambda to `AspectPropertyValue<List<IWeightedValue<{s}>>>`.
- Add necessary includes to `IpIntelligence`.
- Add [[`IPAddress`](https://learn.microsoft.com/en-us/dotnet/api/system.net.ipaddress?view=netstandard-2.0)->[`InetAddress`](https://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html)] mapping to `JavaClassBuilder`.
- Fix `package` parameter being unused by `JavaClassBuilder.BuildClass()`.

### Why

- https://github.com/51Degrees/ip-intelligence-java