### PR TITLE
Fix IPI java accessors 2

### DIFF
--- a/PropertyGenerator/CSClassBuilder.cs
+++ b/PropertyGenerator/CSClassBuilder.cs
@@ -46,36 +46,18 @@ namespace PropertyGenerationTool
             T property,
             Func<string, string> formatType)
         {
-            string typeString;
-            switch (GetPropertyType(property))
+            string typeString = GetPropertyType(property) switch
             {
-                case Type intType when intType == typeof(Int32):
-                    typeString = "int";
-                    break;
-                case Type boolType when boolType == typeof(Boolean):
-                    typeString = "bool";
-                    break;
-                case Type doubleType when doubleType == typeof(Double):
-                    typeString = "double";
-                    break;
-                case Type listType when listType == typeof(IReadOnlyList<string>):
-                    typeString = "IReadOnlyList<string>";
-                    break;
-                case Type floatType when floatType == typeof(float):
-                    typeString = "float";
-                    break;
-                case Type ipType when ipType == typeof(IPAddress):
-                    typeString = "IPAddress";
-                    break;
-                case Type javaScriptType when javaScriptType == typeof(JavaScript):
-                    typeString = "JavaScript";
-                    break;
-                case Type stringType when stringType == typeof(String):
-                default:
-                    typeString = "string";
-                    break;
-            }
-
+                // Keep the branches in sync with [JavaClassBuilder] !!
+                Type intType when intType == typeof(Int32) => "int",
+                Type boolType when boolType == typeof(Boolean) => "bool",
+                Type doubleType when doubleType == typeof(Double) => "double",
+                Type listType when listType == typeof(IReadOnlyList<string>) => "IReadOnlyList<string>",
+                Type floatType when floatType == typeof(float) => "float",
+                Type ipType when ipType == typeof(IPAddress) => "IPAddress",
+                Type javaScriptType when javaScriptType == typeof(JavaScript) => "JavaScript",
+                _ => "string",
+            };
             return formatType(typeString);
         }
 

--- a/PropertyGenerator/DeviceDetection.cs
+++ b/PropertyGenerator/DeviceDetection.cs
@@ -75,6 +75,8 @@ namespace PropertyGenerationTool
                 "DeviceData",
                 _copyright,
                 "fiftyone.devicedetection.shared",
+                " * Interface exposing typed accessors for properties related to a device\n" +
+                " * returned by a device detection engine.",
                 [
                     "fiftyone.pipeline.core.data.types.JavaScript",
                 ],

--- a/PropertyGenerator/IpIntelligence.cs
+++ b/PropertyGenerator/IpIntelligence.cs
@@ -74,6 +74,8 @@ namespace PropertyGenerator
                 "IPIntelligenceData",
                 _copyright,
                 "fiftyone.ipintelligence.shared",
+                " * Interface exposing typed accessors for properties related to an IP.\n" +
+                " * This includes the network, and location.",
                 imports,
                 _engine.Properties.ToArray(),
                 (s) => $"AspectPropertyValue<List<IWeightedValue<{s}>>>",

--- a/PropertyGenerator/JavaClassBuilder.cs
+++ b/PropertyGenerator/JavaClassBuilder.cs
@@ -47,32 +47,18 @@ namespace PropertyGenerationTool
             T property,
             Func<string, string> formatType)
         {
-            string typeString;
-            switch (GetPropertyType(property))
+            string typeString = GetPropertyType(property) switch
             {
-                case Type intType when intType == typeof(Int32):
-                    typeString = "Integer";
-                    break;
-                case Type boolType when boolType == typeof(Boolean):
-                    typeString = "Boolean";
-                    break;
-                case Type doubleType when doubleType == typeof(Double):
-                    typeString = "Double";
-                    break;
-                case Type listType when listType == typeof(IReadOnlyList<string>):
-                    typeString = "List<String>";
-                    break;
-                case Type javaScriptType when javaScriptType == typeof(JavaScript):
-                    typeString = "JavaScript";
-                    break;
-                case Type javaScriptType when javaScriptType == typeof(IPAddress):
-                    typeString = "InetAddress";
-                    break;
-                case Type stringType when stringType == typeof(String):
-                default:
-                    typeString = "String";
-                    break;
-            }
+                // Keep the branches in sync with [CSClassBuilder] !!
+                Type intType when intType == typeof(Int32) => "Integer",
+                Type boolType when boolType == typeof(Boolean) => "Boolean",
+                Type doubleType when doubleType == typeof(Double) => "Double",
+                Type listType when listType == typeof(IReadOnlyList<string>) => "List<String>",
+                Type floatType when floatType == typeof(float) => "Float",
+                Type ipType when ipType == typeof(IPAddress) => "InetAddress",
+                Type javaScriptType when javaScriptType == typeof(JavaScript) => "JavaScript",
+                _ => "String",
+            };
             return formatType(typeString);
         }
 

--- a/PropertyGenerator/JavaClassBuilder.cs
+++ b/PropertyGenerator/JavaClassBuilder.cs
@@ -86,6 +86,7 @@ namespace PropertyGenerationTool
         internal void BuildInterface(
             string name,
             string copyright,
+            string description,
             string package,
             IEnumerable<string> imports,
             T[] properties,
@@ -109,9 +110,7 @@ namespace PropertyGenerationTool
                 writer.WriteLine("// This interface sits at the top of the name space in order to make");
                 writer.WriteLine("// life easier for consumers.");
                 writer.WriteLine("/**");
-                // TODO
-                writer.WriteLine(" * Interface exposing typed accessors for properties related to a device");
-                writer.WriteLine(" * returned by a device detection engine.");
+                writer.WriteLine(description);
                 writer.WriteLine(" */");
                 writer.WriteLine($"public interface {name} extends AspectData");
                 writer.WriteLine("{");


### PR DESCRIPTION
### Changes

- Align switch (on type) statements in C# and Java generators.
- Customize description of IPI Java interface.

### Why

- missing `Float` in Java generation
  - See [[`dfa18029ff44cc132d3de33c62cfa431461ca781`](https://github.com/51Degrees/ip-intelligence-java/pull/10/commits/dfa18029ff44cc132d3de33c62cfa431461ca781)]

### Related

- Expands on #15