### PR TITLE
Add a Rust target to the PropertyGenerator

### DIFF
--- a/PropertyGenerator/Builders/MetaDataRustClassBuilder.cs
+++ b/PropertyGenerator/Builders/MetaDataRustClassBuilder.cs
@@ -1,0 +1,96 @@
+using FiftyOne.MetaData.Entities;
+
+namespace PropertyGenerator.Builders
+{
+    internal class MetaDataRustClassBuilder : RustClassBuilderBase<IPropertyMetaData>
+    {
+        protected override string DataBaseType => "IpIntelligenceDataBase";
+
+        protected override string GetPropertyDescription(IPropertyMetaData property)
+        {
+            return property.Description;
+        }
+
+        protected override string GetPropertyName(IPropertyMetaData property)
+        {
+            return property.Name;
+        }
+
+        protected override string GetPropertyType(IPropertyMetaData property)
+        {
+            var type = property.ValueType switch
+            {
+                // Keep the branches in sync with [CSClassBuilder] and
+                // [JavaClassBuilder] !!
+                ValueTypeEnum.Int => property.IsList ? "Vec<i32>" : "i32",
+                ValueTypeEnum.Bool => property.IsList ? "Vec<bool>" : "bool",
+                ValueTypeEnum.Double => property.IsList ? "Vec<f64>" : "f64",
+                ValueTypeEnum.String => property.IsList ? "Vec<String>" : "String",
+                ValueTypeEnum.Single => property.IsList ? "Vec<f32>" : "f32",
+                // IP addresses are surfaced as their textual form in Rust.
+                ValueTypeEnum.IP => property.IsList ? "Vec<String>" : "String",
+                ValueTypeEnum.JavaScript => property.IsList ? "Vec<String>" : "String",
+                ValueTypeEnum.WKBR => property.IsList ? "Vec<String>" : "String",
+                ValueTypeEnum.WeightedString => "Vec<WeightedValue<String>>",
+                ValueTypeEnum.WeightedInt => "Vec<WeightedValue<i32>>",
+                ValueTypeEnum.WeightedDouble => "Vec<WeightedValue<f64>>",
+                ValueTypeEnum.WeightedSingle => "Vec<WeightedValue<f32>>",
+                ValueTypeEnum.WeightedBool => "Vec<WeightedValue<bool>>",
+                ValueTypeEnum.WeightedByte => "Vec<WeightedValue<Vec<u8>>>",
+                ValueTypeEnum.WeightedIp => "Vec<WeightedValue<String>>",
+                ValueTypeEnum.WeightedWKBR => "Vec<WeightedValue<String>>",
+                _ => "String",
+            };
+
+            return $"AspectPropertyValue<{type}>";
+        }
+
+        protected override string GetStoreGetter(IPropertyMetaData property)
+        {
+            if (IsWeighted(property.ValueType))
+            {
+                // The Rust data base stores every weighted property as a weighted
+                // string list (its candidate values are strings).
+                return "weighted_string";
+            }
+
+            return property.ValueType switch
+            {
+                ValueTypeEnum.Int => "integer",
+                ValueTypeEnum.Bool => "boolean",
+                ValueTypeEnum.Double => "double",
+                ValueTypeEnum.Single => "float",
+                _ => "string",
+            };
+        }
+
+        protected override string GetCoreValueType(IPropertyMetaData property)
+        {
+            if (IsWeighted(property.ValueType))
+            {
+                // Weighted lists surface through the dynamic bag as a flattened
+                // key-value list of value/weight records.
+                return "KeyValueList";
+            }
+
+            return property.ValueType switch
+            {
+                ValueTypeEnum.Int => "Integer",
+                ValueTypeEnum.Bool => "Bool",
+                // The core metadata enum has no single-precision variant, so a
+                // single float is published as a double, as the C# generator does.
+                ValueTypeEnum.Double => "Double",
+                ValueTypeEnum.Single => "Double",
+                ValueTypeEnum.JavaScript => "JavaScript",
+                ValueTypeEnum.String => property.IsList ? "StringList" : "String",
+                _ => "String",
+            };
+        }
+
+        private static bool IsWeighted(ValueTypeEnum valueType)
+        {
+            return valueType >= ValueTypeEnum.WeightedString
+                && valueType <= ValueTypeEnum.WeightedWKBR;
+        }
+    }
+}

--- a/PropertyGenerator/Builders/MetaDataRustDeviceClassBuilder.cs
+++ b/PropertyGenerator/Builders/MetaDataRustDeviceClassBuilder.cs
@@ -1,0 +1,83 @@
+using FiftyOne.MetaData.Entities;
+
+namespace PropertyGenerator.Builders
+{
+    /// <summary>
+    /// Rust class builder for Device Detection.
+    /// The Device Detection Rust data base reads every value out of the dynamic
+    /// property bag, so the type mapping and the by-name getters differ from the
+    /// IP Intelligence builder: integers are `i64`, there are no weighted
+    /// properties, and the getters are the `*_property` accessors on
+    /// `DeviceDataBase`.
+    /// </summary>
+    internal class MetaDataRustDeviceClassBuilder : RustClassBuilderBase<IPropertyMetaData>
+    {
+        protected override string DataBaseType => "DeviceDataBase";
+
+        protected override string GetPropertyDescription(IPropertyMetaData property)
+        {
+            return property.Description;
+        }
+
+        protected override string GetPropertyName(IPropertyMetaData property)
+        {
+            return property.Name;
+        }
+
+        protected override string GetPropertyType(IPropertyMetaData property)
+        {
+            var type = property.ValueType switch
+            {
+                // Keep the branches in sync with [CSClassBuilder] and
+                // [JavaClassBuilder] !! Device Detection integers are i64.
+                ValueTypeEnum.Int => property.IsList ? "Vec<i64>" : "i64",
+                ValueTypeEnum.Bool => property.IsList ? "Vec<bool>" : "bool",
+                ValueTypeEnum.Double => property.IsList ? "Vec<f64>" : "f64",
+                ValueTypeEnum.String => property.IsList ? "Vec<String>" : "String",
+                ValueTypeEnum.Single => property.IsList ? "Vec<f64>" : "f64",
+                ValueTypeEnum.JavaScript => property.IsList ? "Vec<String>" : "String",
+                ValueTypeEnum.WKBR => property.IsList ? "Vec<String>" : "String",
+                _ => "String",
+            };
+
+            return $"AspectPropertyValue<{type}>";
+        }
+
+        protected override string GetStoreGetter(IPropertyMetaData property)
+        {
+            // Kept consistent with GetPropertyType: only the string-like types
+            // render as a list (Vec<String>), and every Device Detection list is
+            // a string list. Any other type, and any unhandled type (which falls
+            // through to a scalar String like the C# and Java generators do),
+            // reads through its scalar getter.
+            return property.ValueType switch
+            {
+                ValueTypeEnum.Int => "integer_property",
+                ValueTypeEnum.Bool => "bool_property",
+                ValueTypeEnum.Double => "double_property",
+                ValueTypeEnum.Single => "double_property",
+                ValueTypeEnum.String => property.IsList ? "string_list_property" : "string_property",
+                ValueTypeEnum.JavaScript => "string_property",
+                ValueTypeEnum.WKBR => property.IsList ? "string_list_property" : "string_property",
+                _ => "string_property",
+            };
+        }
+
+        protected override string GetCoreValueType(IPropertyMetaData property)
+        {
+            // Mirrors GetPropertyType / GetStoreGetter so the published metadata
+            // type matches how the value is stored and read back.
+            return property.ValueType switch
+            {
+                ValueTypeEnum.Int => "Integer",
+                ValueTypeEnum.Bool => "Bool",
+                ValueTypeEnum.Double => "Double",
+                ValueTypeEnum.Single => "Double",
+                ValueTypeEnum.JavaScript => "JavaScript",
+                ValueTypeEnum.String => property.IsList ? "StringList" : "String",
+                ValueTypeEnum.WKBR => property.IsList ? "StringList" : "String",
+                _ => "String",
+            };
+        }
+    }
+}

--- a/PropertyGenerator/Builders/RustClassBuilderBase.cs
+++ b/PropertyGenerator/Builders/RustClassBuilderBase.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using PropertyGenerationTool;
+
+namespace PropertyGenerator.Builders
+{
+    /// <summary>
+    /// Class builder for Rust.
+    /// Emits one source file containing a trait of strongly-typed read accessors,
+    /// the matching impl block that delegates to the hand-written data base, and a
+    /// table pairing each property with its core value type. Methods for getting
+    /// info from a property are extracted so the class is not tied to the type of
+    /// property, mirroring the C# and Java builders.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    abstract class RustClassBuilderBase<T> : ClassBuilderBase<T>
+    {
+        /// <summary>
+        /// The hand-written data base type the generated impl is implemented for,
+        /// and which exposes the by-name store getters delegated to.
+        /// </summary>
+        protected abstract string DataBaseType { get; }
+
+        /// <summary>
+        /// The by-name store getter on the data base to delegate to for a property,
+        /// e.g. "string", "integer", "boolean", "float", "weighted_string".
+        /// </summary>
+        protected abstract string GetStoreGetter(T property);
+
+        /// <summary>
+        /// The core PropertyValueType variant name a property is published as in
+        /// the metadata table, e.g. "String", "Integer", "KeyValueList".
+        /// </summary>
+        protected abstract string GetCoreValueType(T property);
+
+        /// <summary>
+        /// Convert a 51Degrees PascalCase property name into an idiomatic Rust
+        /// snake_case accessor name. An underscore is inserted before an upper-case
+        /// letter that follows a lower-case letter or a digit, and before an
+        /// upper-case letter that starts a word (an upper-case run followed by a
+        /// lower-case letter). Trailing digits stay attached to the preceding word.
+        /// </summary>
+        internal static string ToSnakeCase(string name)
+        {
+            var cleaned = name.Replace("/", "").Replace("-", "");
+            var sb = new StringBuilder();
+            for (int i = 0; i < cleaned.Length; i++)
+            {
+                char c = cleaned[i];
+                if (char.IsUpper(c))
+                {
+                    bool prevLowerOrDigit = i > 0 &&
+                        (char.IsLower(cleaned[i - 1]) || char.IsDigit(cleaned[i - 1]));
+                    bool prevUpper = i > 0 && char.IsUpper(cleaned[i - 1]);
+                    bool nextLower = i + 1 < cleaned.Length && char.IsLower(cleaned[i + 1]);
+                    if (i > 0 && (prevLowerOrDigit || (prevUpper && nextLower)))
+                    {
+                        sb.Append('_');
+                    }
+                    sb.Append(char.ToLowerInvariant(c));
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+
+        internal string GetGetterName(T property)
+        {
+            return ToSnakeCase(GetPropertyName(property));
+        }
+
+        /// <summary>
+        /// The doc text for a property: its metadata description, or a generated
+        /// fallback naming the property when the metadata carries no description,
+        /// so the accessor always has a non-empty doc comment.
+        /// </summary>
+        private string PropertyDoc(T property)
+        {
+            var description = GetPropertyDescription(property);
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                return $"The `{GetPropertyName(property)}` property.";
+            }
+            return description;
+        }
+
+        internal void Build(
+            string copyright,
+            string traitName,
+            string moduleDescription,
+            string traitDescription,
+            IEnumerable<string> uses,
+            T[] properties,
+            string outputPath)
+        {
+            var filtered = properties
+                .Where(p => Constants.excludedProperties.Contains(GetPropertyName(p)) == false)
+                .OrderBy(GetPropertyName)
+                .ToArray();
+
+            using var outputStream = new FileStream(outputPath, FileMode.Create);
+            using var writer = new StreamWriter(outputStream);
+
+            writer.WriteLine(copyright);
+            WriteInnerDoc(writer, moduleDescription);
+            // Property descriptions are taken verbatim from the metadata, so some
+            // contain bare URLs or angle-bracketed HTML-like tokens (the HTML5
+            // feature-support properties name elements such as `<header>`).
+            // Rustdoc would otherwise warn on these, so the lints are allowed for
+            // this generated file rather than mangling the descriptions.
+            writer.WriteLine("#![allow(rustdoc::bare_urls, rustdoc::invalid_html_tags)]");
+            writer.WriteLine();
+            foreach (var use in uses)
+            {
+                writer.WriteLine($"use {use};");
+            }
+            writer.WriteLine();
+
+            // Trait.
+            WriteOuterDoc(writer, traitDescription, "");
+            writer.WriteLine($"pub trait {traitName}: AspectData {{");
+            for (int i = 0; i < filtered.Length; i++)
+            {
+                var property = filtered[i];
+                WriteOuterDoc(writer, PropertyDoc(property), "    ");
+                writer.WriteLine(
+                    $"    fn {GetGetterName(property)}(&self) -> {GetPropertyType(property)};");
+                if (i != filtered.Length - 1)
+                {
+                    writer.WriteLine();
+                }
+            }
+            writer.WriteLine("}");
+            writer.WriteLine();
+
+            // Impl that delegates to the by-name store getters.
+            writer.WriteLine($"impl {traitName} for {DataBaseType} {{");
+            for (int i = 0; i < filtered.Length; i++)
+            {
+                var property = filtered[i];
+                writer.WriteLine(
+                    $"    fn {GetGetterName(property)}(&self) -> {GetPropertyType(property)} {{");
+                writer.WriteLine(
+                    $"        self.{GetStoreGetter(property)}(\"{GetPropertyName(property)}\")");
+                writer.WriteLine("    }");
+                if (i != filtered.Length - 1)
+                {
+                    writer.WriteLine();
+                }
+            }
+            writer.WriteLine("}");
+            writer.WriteLine();
+
+            // Property value-type table, used to publish per-property metadata.
+            writer.WriteLine(
+                "/// Every generated property paired with its core value type, in name");
+            writer.WriteLine(
+                "/// order. The data base uses this to publish per-property metadata.");
+            writer.WriteLine(
+                "pub const GENERATED_PROPERTY_TYPES: &[(&str, PropertyValueType)] = &[");
+            foreach (var property in filtered)
+            {
+                writer.WriteLine(
+                    $"    (\"{GetPropertyName(property)}\", " +
+                    $"PropertyValueType::{GetCoreValueType(property)}),");
+            }
+            writer.WriteLine("];");
+        }
+
+        /// <summary>
+        /// Write a description as one or more `//!` inner doc lines.
+        /// </summary>
+        private static void WriteInnerDoc(StreamWriter writer, string description)
+        {
+            foreach (var line in SplitLines(description))
+            {
+                writer.WriteLine(line.Length == 0 ? "//!" : "//! " + line);
+            }
+        }
+
+        /// <summary>
+        /// Write a description as one or more `///` outer doc lines at the given
+        /// indent.
+        /// </summary>
+        private static void WriteOuterDoc(StreamWriter writer, string description, string indent)
+        {
+            foreach (var line in SplitLines(description))
+            {
+                writer.WriteLine(line.Length == 0 ? $"{indent}///" : $"{indent}/// " + line);
+            }
+        }
+
+        private static IEnumerable<string> SplitLines(string description)
+        {
+            return (description ?? string.Empty)
+                .Replace("\r\n", "\n")
+                .Split('\n');
+        }
+    }
+}

--- a/PropertyGenerator/DeviceDetection.cs
+++ b/PropertyGenerator/DeviceDetection.cs
@@ -103,6 +103,42 @@ namespace PropertyGenerationTool
                 outputPath: basePath + "/DeviceDataBase.java");
         }
 
+        public override void BuildRust(string basePath)
+        {
+            Console.WriteLine(String.Format(
+                "Building device_data.rs in '{0}'.",
+                new DirectoryInfo(basePath).FullName));
+            Directory.CreateDirectory(basePath);
+            var builder = new MetaDataRustDeviceClassBuilder();
+
+            builder.Build(
+                copyright: GetCopyright(),
+                traitName: "DeviceData",
+                moduleDescription:
+                    "Generated strongly-typed read accessors for Device Detection.\n" +
+                    "\n" +
+                    "This file is produced by the 51Degrees PropertyGenerator tool from the\n" +
+                    "common metadata. It defines the [`DeviceData`] trait, one accessor per\n" +
+                    "documented property, and implements it for the hand-written\n" +
+                    "[`DeviceDataBase`] by delegating to its by-name dynamic-bag getters.\n" +
+                    "Each property resolves to a single typed value (or a list for the\n" +
+                    "list-valued properties).",
+                traitDescription:
+                    "Strongly-typed read accessors for Device Detection properties.\n" +
+                    "\n" +
+                    "Covers the hardware, operating system, browser and crawler properties of\n" +
+                    "a device. Each accessor returns an [`AspectPropertyValue`] wrapping the\n" +
+                    "property's value type, so an absent value carries the no-value reason.",
+                uses:
+                [
+                    "fiftyone_pipeline_core::PropertyValueType",
+                    "fiftyone_pipeline_engines::{AspectData, AspectPropertyValue}",
+                    "crate::data::DeviceDataBase",
+                ],
+                properties: GetProperties(),
+                outputPath: basePath + "/device_data.rs");
+        }
+
         private static readonly ProductEnum[] DdProducts = [
             ProductEnum.V4Enterprise,
             ProductEnum.V4TAC,

--- a/PropertyGenerator/GeneratorBase.cs
+++ b/PropertyGenerator/GeneratorBase.cs
@@ -16,6 +16,16 @@ namespace PropertyGenerator
         public abstract void BuildJava(string path);
 
         /// <summary>
+        /// Build the data classes for Rust. The default does nothing so a
+        /// generator that has no Rust target need not implement it; override to
+        /// emit Rust.
+        /// </summary>
+        public virtual void BuildRust(string path)
+        {
+            Console.WriteLine("Rust generation is not implemented for this generator.");
+        }
+
+        /// <summary>
         /// Gets the copyright text + the auto-generation message
         /// </summary>
         protected static string GetCopyright()

--- a/PropertyGenerator/IGenerator.cs
+++ b/PropertyGenerator/IGenerator.cs
@@ -25,5 +25,11 @@ namespace PropertyGenerator
         /// </summary>
         /// <param name="path"></param>
         void BuildJava(string path);
+        /// <summary>
+        /// Build the data classes for Rust and write the .rs files to the directory
+        /// provided.
+        /// </summary>
+        /// <param name="path"></param>
+        void BuildRust(string path);
     }
 }

--- a/PropertyGenerator/IpIntelligence.cs
+++ b/PropertyGenerator/IpIntelligence.cs
@@ -104,6 +104,43 @@ namespace PropertyGenerator
                 outputPath: basePath + "/IPIntelligenceDataBase.java");
         }
 
+        public override void BuildRust(string basePath)
+        {
+            Console.WriteLine(String.Format(
+                "Building ip_intelligence_data.rs in '{0}'.",
+                new DirectoryInfo(basePath).FullName));
+            Directory.CreateDirectory(basePath);
+            var builder = new MetaDataRustClassBuilder();
+
+            builder.Build(
+                copyright: GetCopyright(),
+                traitName: "IpIntelligenceData",
+                moduleDescription:
+                    "Generated strongly-typed read accessors for IP Intelligence.\n" +
+                    "\n" +
+                    "This file is produced by the 51Degrees PropertyGenerator tool from the\n" +
+                    "common metadata. It defines the [`IpIntelligenceData`] trait, one accessor\n" +
+                    "per documented property, and implements it for the hand-written\n" +
+                    "[`IpIntelligenceDataBase`] by delegating to its by-name stores. Plain\n" +
+                    "properties resolve to a single typed value; the weighted properties\n" +
+                    "(the country-code distributions and `Mcc`) resolve to an ordered list of\n" +
+                    "weighted candidates.",
+                traitDescription:
+                    "Strongly-typed read accessors for IP Intelligence properties.\n" +
+                    "\n" +
+                    "Covers the network and location properties of an IP. Each accessor\n" +
+                    "returns an [`AspectPropertyValue`] wrapping the property's value type, so\n" +
+                    "an absent value carries the engine's no-value reason.",
+                uses:
+                [
+                    "fiftyone_pipeline_core::{PropertyValueType, WeightedValue}",
+                    "fiftyone_pipeline_engines::{AspectData, AspectPropertyValue}",
+                    "crate::data::IpIntelligenceDataBase",
+                ],
+                properties: GetProperties(),
+                outputPath: basePath + "/ip_intelligence_data.rs");
+        }
+
         private static readonly ProductEnum[] IpiProducts = [
             ProductEnum.IPIV4Enterprise,
             ProductEnum.IPIV4Lite,

--- a/PropertyGenerator/Program.cs
+++ b/PropertyGenerator/Program.cs
@@ -34,6 +34,8 @@ namespace PropertyGenerationTool
                 deviceDetection.BuildCSharp(Path.Combine(args[1], "CSharp"));
                 // Java.
                 deviceDetection.BuildJava(Path.Combine(args[1], "Java"));
+                // Rust
+                deviceDetection.BuildRust(Path.Combine(args[1], "Rust"));
                 Console.WriteLine("Done Device Detection.");
             }
             else if (args[0].Equals(IPI, StringComparison.InvariantCultureIgnoreCase))
@@ -43,6 +45,8 @@ namespace PropertyGenerationTool
                 ipIntelligence.BuildCSharp(Path.Combine(args[1], "CSharp"));
                 // Java
                 ipIntelligence.BuildJava(Path.Combine(args[1], "Java"));
+                // Rust
+                ipIntelligence.BuildRust(Path.Combine(args[1], "Rust"));
                 Console.WriteLine("Done IP Intelligence");
             }
             else


### PR DESCRIPTION
@
## What

Adds a Rust generation target to the `PropertyGenerator`, alongside the existing C# and Java targets, for both **IP Intelligence** and **Device Detection**.

For each product the tool emits one Rust source file containing:
- the data trait (`IpIntelligenceData` / `DeviceData`) with one strongly-typed accessor per documented property,
- the `impl` of that trait for the hand-written data base, delegating by property name, and
- a `GENERATED_PROPERTY_TYPES` table the data base uses to publish metadata.

## Details

- New `Builders/RustClassBuilderBase.cs` holds the shared emission logic: PascalCase to idiomatic snake_case accessor names, single-file trait + impl + type table, an inner module doc, and a fallback doc for properties with no description. The `rustdoc::bare_urls` and `rustdoc::invalid_html_tags` lints are allowed for the generated file so the Device Detection descriptions (which name HTML elements and carry URLs) generate cleanly.
- `Builders/MetaDataRustClassBuilder.cs` maps the IP Intelligence types (i32 integers; weighted properties as `Vec<WeightedValue<T>>`; the `string`/`integer`/`boolean`/`float`/`weighted_string` getters).
- `Builders/MetaDataRustDeviceClassBuilder.cs` maps the Device Detection types (i64 integers, f64 doubles, no weighting; the `*_property` getters on `DeviceDataBase`).
- IP addresses are surfaced as their string form in both.
- `BuildRust` is added to `IGenerator` with a no-op default on `GeneratorBase`; both product generators implement it, and `Program` runs it into a `Rust` output directory.

Generated output is run through `rustfmt` as the final step (it only reorders imports), the same convention other generated bindings use.
@