### PR TITLE
PropertyGenerator: float metadata to 5.*, engines to 4.5.*

### DIFF
--- a/PropertyGenerator/PropertyGenerator.csproj
+++ b/PropertyGenerator/PropertyGenerator.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.DeviceDetection.Hash.Engine.OnPremise" Version="4.4.213" />
-    <PackageReference Include="FiftyOne.IpIntelligence.Engine.OnPremise" Version="4.5.0-alpha.50" />
-    <PackageReference Include="FiftyOne.MetaData" Version="5.1.12" />
+    <PackageReference Include="FiftyOne.DeviceDetection.Hash.Engine.OnPremise" Version="4.5.*" />
+    <PackageReference Include="FiftyOne.IpIntelligence.Engine.OnPremise" Version="4.5.*" />
+    <PackageReference Include="FiftyOne.MetaData" Version="5.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Problem

`PropertyGenerator` builds its property list from the metadata **embedded in the referenced `FiftyOne.MetaData` package** (`new MetaDataService()` → `EmbeddedResourceService`), not from the `common-metadata` checkout. `generate-accessors.ps1` passes no metadata path, so the `metadata-branch: main` input to `nightly-data-file-change` never feeds the generator - the pinned package version is the real source of truth.

That reference was hardcoded to `FiftyOne.MetaData` **5.1.12** (tagged 2026-04-16). Any property merged to common-metadata after that date shipped only in later package versions (now 5.1.48), so the generator never saw it, produced no diff (`No property changes, so not creating a pull request`), and opened no `properties-update` PR. The accessor-update PRs in downstream repos silently stopped in April.

Concrete fallout: [device-detection-java nightly](https://github.com/51Degrees/device-detection-java/actions/runs/29716532437) is red because `Values_Hash_TypedGetters` finds `IsVerifiediPhone` / `IsVerifiediPhoneJavaScript` in the data file with no matching getters in `DeviceData` - the getters were never generated.

The two engine references were stale for the same reason (no update automation in `tools`): `Hash.Engine.OnPremise` at `4.4.213` and `IpIntelligence.Engine.OnPremise` pinned to a prerelease `4.5.0-alpha.50`.

## Change

Float the references in `PropertyGenerator.csproj`:

| Package | Before | After |
| --- | --- | --- |
| `FiftyOne.MetaData` | `5.1.12` | `5.*` |
| `FiftyOne.DeviceDetection.Hash.Engine.OnPremise` | `4.4.213` | `4.5.*` |
| `FiftyOne.IpIntelligence.Engine.OnPremise` | `4.5.0-alpha.50` | `4.5.*` |

The generator is run from source (`dotnet run`) in each consuming repo's nightly with an unlocked restore, so floating means every nightly picks up the latest metadata automatically. Generated output is committed and diffed, so any change still surfaces as a reviewable `properties-update` PR. `4.5.*` on the engines tracks the current line while excluding the old `4.1.0-beta*` tags and any future major bump.

## Verification (local, against the live feed)

- Restore resolves to MetaData **5.1.48**, Hash **4.5.125**, IPI **4.5.99** (off the alpha).
- `dotnet build -c Release` succeeds - only the three pre-existing warnings, none new.
- Running the generator (`dotnet run -- HashV41 …`) now emits the previously-missing getters:
  ```java
  AspectPropertyValue<String>     getIsVerifiediPhone();
  AspectPropertyValue<JavaScript> getIsVerifiediPhoneJavaScript();
  ```

## After merge

Re-run the nightly (or `Data File Change`) on the accessor-generating repos so they regenerate and open their `properties-update` PRs: device-detection-java, device-detection-dotnet, ip-intelligence-dotnet, ip-intelligence-java. device-detection-java's nightly is the one currently red.
